### PR TITLE
just hit #2 and this resolves it

### DIFF
--- a/lib/Image/WordCloud.pm
+++ b/lib/Image/WordCloud.pm
@@ -151,13 +151,13 @@ sub new {
 		}
 		
 		# Otherwise, try using ./share/fonts (so testing can be done)
-		if (! $opts{'font_path'}) {
+		if (! $opts{'font_path'} and exists $ENV{'HARNESS_ACTIVE'} and $ENV{'HARNESS_ACTIVE'}) {
 			my $local_font_path = File::Spec->catdir(".", "share", "fonts");
 			unless (-d $local_font_path) {
-				#carp sprintf "Local font path '%s' not found", $local_font_path;
-			}
-			
+				carp sprintf "Local font path '%s' not found", $local_font_path;
+			} else {
 			$opts{'font_path'} = $local_font_path;
+		}
 		}
 		
 		# If we still haven't found a font path, find the font path with File::ShareDir


### PR DESCRIPTION
`$opts{'font_path'}` was getting set to `share/fonts` which doesn't exist in working dir except for running under `make test` situation. So check for that situation and only run the block there.